### PR TITLE
Remove any residual margin from iframe body

### DIFF
--- a/js/example.js
+++ b/js/example.js
@@ -34,6 +34,8 @@ function renderIframe(placementElement, html) {
   var resizeInterval = setInterval(
     function() {
       if (iframe.contentDocument.readyState == 'complete') {
+        // remove any residual margin
+        iframe.contentDocument.body.style.margin = 0;
         // Add extra spacing to catch edge cases
         const frameHeight = iframe.contentDocument.body.scrollHeight + 10;
         iframe.height = frameHeight + "px";


### PR DESCRIPTION
## Done

This removes any margin used for testing/demo purposes

## QA

- Run `npm i`
- Run `npm run build`
- Run `npm start`
- View `http://127.0.0.1:8080`
- `<iframe>` examples should have `margin:0` on `<body>` tag