### PR TITLE
Trim whitespace from the source code

### DIFF
--- a/js/example.js
+++ b/js/example.js
@@ -49,7 +49,7 @@ function renderIframe(placementElement, html) {
 
 function renderCodeBlock(placementElement, html) {
   var pattern = /<body[^>]*>((.|[\n\r])*)<\/body>/im;
-  var patternCode = document.createTextNode(pattern.exec(html)[1]);
+  var patternCode = document.createTextNode(pattern.exec(html)[1].trim());
   var pre = document.createElement('pre');
   var code = document.createElement('code');
 

--- a/testing/index.html
+++ b/testing/index.html
@@ -3,6 +3,23 @@
 <head>
   <title>Example JS</title>
   <meta charset='utf-8'>
+  <style>
+    pre {
+      background-color: #f7f7f7;
+      text-align: left;
+      border: 1px solid #cdcdcd;
+      border-radius: 4px;
+      font-family: Ubuntu Mono;
+      font-size: 1em;
+      font-weight: 300;
+      margin: .5em 0;
+      padding: .7em 1em;
+      width: 100%;
+      white-space: pre-wrap;
+      word-spacing: normal;
+      word-wrap: break-word;
+    }
+  </style>
 </head>
 <body>
   <h1>Example JS test page</h1>
@@ -20,7 +37,7 @@
     <a href="../pattern/card.html" class="js-example">Example link</a>
   </div>
   <h2>Remote origin</h2>
-  <a href="https://ubuntudesign.github.io/vanilla-framework/examples/patterns/inline-images/" class="js-example">Example link</a>
+  <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/blockquotes/" class="js-example">Example link</a>
 
   <script src="../build/main.bundle.js"></script>
 </body>


### PR DESCRIPTION
## Done
Trim the white space from the beginning and end of the source code. Added some `pre` styling to see the edge of the code block.

## QA
- Pull this branch
- Run `npm i`
- Run `npm run build`
- Run `npm start`
- Then go to http://127.0.0.1:8080/testing/
- Scroll down to the "Remote origin" section
- Check that the code block has no whitespace at the beginning or at the end

## Details:
Fixes https://github.com/canonical-webteam/example-js/issues/14