### PR TITLE
Compile package with rollup, including commonJS support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    ["latest", {
+      "es2015": {
+        "modules": false
+      }
+    }]
+  ],
+  "plugins": ["external-helpers"]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a small script written in javascript to convert a link to a pattern example with a code block.",
   "main": "js/example.js",
   "scripts": {
-    "build": "mkdir -p build && node_modules/.bin/babel --presets es2015 js/example.js -o build/main.bundle.js --no-comments --minified",
+    "build": "rollup -c",
     "start": "http-server"
   },
   "keywords": [
@@ -21,7 +21,16 @@
   "devDependencies": {
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
-    "http-server": "^0.9.0"
+    "babel-preset-latest": "^6.24.0",
+    "http-server": "^0.9.0",
+    "prismjs": "^1.6.0",
+    "rollup": "^0.41.5",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-uglify": "^1.0.1",
+    "uglify-js": "^2.8.12"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,20 @@
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+import uglify from 'rollup-plugin-uglify';
+
+export default {
+  entry: 'js/example.js',
+  format: 'cjs',
+  plugins: [
+    resolve(),
+    commonjs({
+      include: 'node_modules/**',
+    }),
+    babel({
+      exclude: 'node_modules/**'
+    }),
+    uglify()
+  ],
+  dest: 'build/main.bundle.js'
+};


### PR DESCRIPTION
Change `npm run build` to use rollup and create rollup and babel config files.

Modules can then be imported with:
```
import Prism from 'prismjs';
```