### PR TITLE
Add padding to the iframe example

### DIFF
--- a/js/example.js
+++ b/js/example.js
@@ -52,6 +52,8 @@ function renderIframe(placementElement, html) {
       if (iframe.contentDocument.readyState == 'complete') {
         // remove any residual margin
         iframe.contentDocument.body.style.margin = 0;
+        // add padding to see shadows pattern shadows
+        iframe.contentDocument.body.style.padding = '0 4px';
         // Add extra spacing to catch edge cases
         const frameHeight = iframe.contentDocument.body.scrollHeight + 10;
         iframe.height = frameHeight + "px";


### PR DESCRIPTION
## Done
Added a small amount of horizontal padding to the rendered example as to display borders and shadows in patterns.

## QA
- Pull code
- If not installed, run `npm i`
- Run `npm run build`
- Run `npm start`
- Go to http://127.0.0.1:8080/
- See that the body inside the iframe has 4px padding left and right

## Details
Fixes https://github.com/canonical-webteam/example-js/issues/23