### PR TITLE
Remove scripts from generated code blocks

### DIFF
--- a/js/example.js
+++ b/js/example.js
@@ -67,7 +67,8 @@ function renderIframe(placementElement, html) {
 
 function renderCodeBlock(placementElement, html) {
   var pattern = /<body[^>]*>((.|[\n\r])*)<\/body>/im;
-  var patternCode = document.createTextNode(pattern.exec(html)[1].trim());
+  var source = stripScripts(pattern.exec(html)[1].trim());
+  var patternCode = document.createTextNode(source);
   var pre = document.createElement('pre');
   var code = document.createElement('code');
 
@@ -76,11 +77,22 @@ function renderCodeBlock(placementElement, html) {
   pre.appendChild(code);
   hljs.highlightBlock(code);
 
-  for(let classname in highlightStyles) {
+  for (let classname in highlightStyles) {
     pre.querySelectorAll('.' + classname).forEach(node => {
       node.setAttribute('style', highlightStyles[classname]);
     });
   }
 
   placementElement.parentNode.insertBefore(pre, placementElement);
+}
+
+function stripScripts(source) {
+  var div = document.createElement('div');
+  div.innerHTML = source;
+  var scripts = div.getElementsByTagName('script');
+  var i = scripts.length;
+  while (i--) {
+    scripts[i].parentNode.removeChild(scripts[i]);
+  }
+  return div.innerHTML;
 }

--- a/pattern/interactive.html
+++ b/pattern/interactive.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Card</title>
+  <meta charset='utf-8'>
+  <style>
+    .card {
+      border: 1px solid #888;
+      background-color: #f8f8f8;
+      padding: 1rem;
+      border-radius: 2px;
+    }
+    .card.highlight {
+      box-shadow: 0 1px 5px 1px hsla(0,0%,7%,.2);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h2>title</h2>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute.
+    </p>
+  </div>
+  <script>
+    var card = document.querySelector('.card');
+    card.addEventListener('click', function(e) {
+      card.classList.toggle('highlight');
+    })
+  </script>
+</body>
+</html>

--- a/testing/index.html
+++ b/testing/index.html
@@ -36,8 +36,14 @@
   <div>
     <a href="../pattern/card.html" class="js-example">Example link</a>
   </div>
+  <hr />
   <h2>Remote origin</h2>
   <a href="https://vanilla-framework.github.io/vanilla-framework/examples/base/blockquotes/" class="js-example">Example link</a>
+  <h2>With script</h2>
+  <div>
+    <a href="../pattern/interactive.html" class="js-example">Example link</a>
+  </div>
+
 
   <script src="../build/main.bundle.js"></script>
 </body>


### PR DESCRIPTION
## Done
Created a function to strip scripts from the code blocks. Added an example to test. Also tidied up a code a little in places. 

## QA
- Pull code
- `npm install`
- `npm run build`
- `npm run start`
- Go to http://127.0.0.1:8080/testing/
- Scroll to the bottom to the "With script" section
- Check there is no script in the code block
- Click on the card in the example and check it toggles to highlight

## Details
Fixes https://github.com/canonical-webteam/example-js/issues/28