### PR TITLE
Add "Copy to clipboard" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <title>Example JS</title>
   <meta charset='utf-8'>
+  <link rel="stylesheet" href="/build/styles.css" />
 </head>
 <body>
   <h1>Example JS</h1>

--- a/js/example.js
+++ b/js/example.js
@@ -53,7 +53,7 @@ function renderIframe(placementElement, html) {
         // remove any residual margin
         iframe.contentDocument.body.style.margin = 0;
         // add padding to see shadows pattern shadows
-        iframe.contentDocument.body.style.padding = '0 4px';
+        iframe.contentDocument.body.style.padding = '4px';
         // Add extra spacing to catch edge cases
         const frameHeight = iframe.contentDocument.body.scrollHeight + 10;
         iframe.height = frameHeight + "px";
@@ -71,10 +71,18 @@ function renderCodeBlock(placementElement, html) {
   var patternCode = document.createTextNode(source);
   var pre = document.createElement('pre');
   var code = document.createElement('code');
+  var copyBtn = document.createElement('button');
 
-  code.appendChild(patternCode);
-  code.classList.add('html');
+  // Set attributes of code block
+  pre.classList.add('p-code-example');
+  code.classList.add('html', 'p-code-example__code');
+  copyBtn.classList.add('p-code-example__copy-btn');
+  copyBtn.title = 'Copy to clipboard';
+
+  // Build code block structure
   pre.appendChild(code);
+  pre.appendChild(copyBtn);
+  code.appendChild(patternCode);
   hljs.highlightBlock(code);
 
   for (let classname in highlightStyles) {
@@ -84,6 +92,8 @@ function renderCodeBlock(placementElement, html) {
   }
 
   placementElement.parentNode.insertBefore(pre, placementElement);
+
+  copyBtn.addEventListener('click', () => setClipboard(source));
 }
 
 function stripScripts(source) {
@@ -95,4 +105,17 @@ function stripScripts(source) {
     scripts[i].parentNode.removeChild(scripts[i]);
   }
   return div.innerHTML;
+}
+
+function setClipboard(value) {
+  const tempTextarea = document.createElement("textarea");
+  tempTextarea.value = value;
+  document.body.appendChild(tempTextarea);
+  tempTextarea.select();
+  try {
+    document.execCommand('copy');
+  } catch (error) {
+    console.warn(`Unable to copy: ${error.message}`);
+  }
+  document.body.removeChild(tempTextarea);
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "This is a small script written in javascript to convert a link to a pattern example with a code block.",
   "main": "js/example.js",
   "scripts": {
-    "build": "mkdir -p build && node_modules/.bin/babel --presets es2015 js/*.js -o build/main.bundle.js --no-comments --minified",
+    "build": "mkdir -p build && npm run build-css && node_modules/.bin/babel --presets es2015 js/*.js -o build/main.bundle.js --no-comments --minified",
+    "build-css": "node-sass --include-path node_modules scss --output build",
     "start": "http-server"
   },
   "keywords": [
     "javascript",
     "pattern",
-    "libaray",
+    "library",
     "patterns",
     "examples",
     "code",
@@ -22,6 +23,8 @@
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-preset-es2015": "^6.22.0",
-    "http-server": "^0.9.0"
+    "http-server": "^0.9.0",
+    "node-sass": "^4.9.0",
+    "vanilla-framework": "^1.7.1"
   }
 }

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -1,0 +1,27 @@
+@import 'vanilla-framework/scss/vanilla';
+@include vf-b-code;
+@include vf-b-button;
+
+$copy-btn-margin: 1rem;
+$copy-btn-size: 2.5rem;
+$code-example-max-height: 22.5rem;
+
+.p-code-example {
+  max-height: $code-example-max-height;
+  padding-right: $copy-btn-size + $copy-btn-margin;
+  position: relative;
+  white-space: pre-wrap;
+
+  &__copy-btn {
+    @include vf-icon-copy(vf-url-friendly-color($color-mid-dark));
+    background: {
+      position: center;
+      repeat: no-repeat;
+    }
+    height: $copy-btn-size;
+    position: absolute;
+    right: $copy-btn-margin;
+    top: $copy-btn-margin;
+    width: $copy-btn-size;
+  }
+}

--- a/testing/index.html
+++ b/testing/index.html
@@ -3,23 +3,7 @@
 <head>
   <title>Example JS</title>
   <meta charset='utf-8'>
-  <style>
-    pre {
-      background-color: #f7f7f7;
-      text-align: left;
-      border: 1px solid #cdcdcd;
-      border-radius: 4px;
-      font-family: Ubuntu Mono;
-      font-size: 1em;
-      font-weight: 300;
-      margin: .5em 0;
-      padding: .7em 1em;
-      width: 100%;
-      white-space: pre-wrap;
-      word-spacing: normal;
-      word-wrap: break-word;
-    }
-  </style>
+  <link rel="stylesheet" href="/build/styles.css" />
 </head>
 <body>
   <h1>Example JS test page</h1>


### PR DESCRIPTION
## Done

- Added a "Copy to clipboard" button to rendered code examples
- Gave each of the code block elements classnames, so they're easier to target with stylesheets:
  - `.p-code-example`
  - `.p-code-example__code`
  - `.p-code-example__copy-btn`
- Added `css/styles.css` with current Vanilla codeblock and button styling, and applied to `index.html` and `testing/index.html`
- Added 4px top/bottom padding to iframes so that focused inputs don't get cropped

## QA

- Pull code
- Run `npm install`, then `npm run build`, then `npm run start`
- Open http://127.0.0.1:8080
- Check there is a copy to clipboard button in the top right of the codeblock
- Check that clicking it copies the codeblock to clipboard properly (e.g. paste to a text editor and see that it matches)

## Fixes

Fixes #30, fixes #22, fixes https://github.com/vanilla-framework/vanilla-framework/issues/1436