### PR TITLE
Improve vanilla include

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Then run the local server with the following command.
 npm start
 ```
 
-Open a browser and access http://localhost:8080
+Open a browser and access http://localhost:8082
 
 ## Testing
 
-You can view the testing page at http://127.0.0.1:8080/testing/
+You can view the testing page at http://127.0.0.1:8082/testing/
 
 If you find you fix a problem please add an example to it for quick testing.

--- a/js/example.js
+++ b/js/example.js
@@ -69,17 +69,21 @@ function renderCodeBlock(placementElement, html) {
   var pattern = /<body[^>]*>((.|[\n\r])*)<\/body>/im;
   var source = stripScripts(pattern.exec(html)[1].trim());
   var patternCode = document.createTextNode(source);
+  var container = document.createElement('div');
   var pre = document.createElement('pre');
   var code = document.createElement('code');
   var copyBtn = document.createElement('button');
 
   // Set attributes of code block
-  pre.classList.add('p-code-example');
+
+  container.classList.add('p-code-example');
+  pre.classList.add('p-code-example__pre');
   code.classList.add('html', 'p-code-example__code');
   copyBtn.classList.add('p-code-example__copy-btn');
   copyBtn.title = 'Copy to clipboard';
 
   // Build code block structure
+  container.appendChild(pre);
   pre.appendChild(code);
   pre.appendChild(copyBtn);
   code.appendChild(patternCode);
@@ -91,7 +95,7 @@ function renderCodeBlock(placementElement, html) {
     });
   }
 
-  placementElement.parentNode.insertBefore(pre, placementElement);
+  placementElement.parentNode.insertBefore(container, placementElement);
 
   copyBtn.addEventListener('click', () => setClipboard(source));
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "js/example.js",
   "scripts": {
     "build": "mkdir -p build && npm run build-css && node_modules/.bin/babel --presets es2015 js/*.js -o build/main.bundle.js --no-comments --minified",
-    "build-css": "node-sass --include-path node_modules scss --output build",
+    "build-css": "node-sass --include-path node_modules scss --output-style compressed --output build",
     "start": "http-server"
   },
   "keywords": [

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,0 +1,3 @@
+$copy-btn-margin: 1rem;
+$copy-btn-size: 2.5rem;
+$code-example-max-height: 22.5rem;

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -8,10 +8,13 @@
   @include vf-b-placeholders;
   @include vf-b-code;
   @include vf-b-button;
-  max-height: $code-example-max-height;
-  padding-right: $copy-btn-size + $copy-btn-margin;
-  position: relative;
-  white-space: pre-wrap;
+
+  &__pre {
+    max-height: $code-example-max-height;
+    padding-right: $copy-btn-size + $copy-btn-margin;
+    position: relative;
+    white-space: pre-wrap;
+  }
 
   &__copy-btn {
     @include vf-icon-copy(vf-url-friendly-color($color-mid-dark));

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -1,12 +1,13 @@
-@import 'vanilla-framework/scss/vanilla';
-@include vf-b-code;
-@include vf-b-button;
-
-$copy-btn-margin: 1rem;
-$copy-btn-size: 2.5rem;
-$code-example-max-height: 22.5rem;
+@import 'settings';
+@import 'vanilla-framework/scss/base_placeholders';
+@import 'vanilla-framework/scss/base_code';
+@import 'vanilla-framework/scss/base_button';
+@import 'vanilla-framework/scss/patterns_icons';
 
 .p-code-example {
+  @include vf-b-placeholders;
+  @include vf-b-code;
+  @include vf-b-button;
   max-height: $code-example-max-height;
   padding-right: $copy-btn-size + $copy-btn-margin;
   position: relative;


### PR DESCRIPTION
## Done
- Limited the Vanilla import to just the patterns used saving ~80% of the outputted CSS.
- Scoped the styling to just the component so nothing can leak
- Compressed the outputted CSS reducing it by another ~30%
- Moved the setting variables to there own file
- Corrected the instructions in the README

## QA
- Pull down this code
- Run `npm install` if not already installed
- Run `npm run build` which will build the assets into the build directory
- Run `npm start` this starts a http server at port 8082
- Go to http://localhost:8082
- See that the example works and it looks like the usage on [vanillaframework.io docs](https://docs.vanillaframework.io/en/patterns/breadcrumbs)